### PR TITLE
Revert "pkg: fedora: Disable wrong NX compatibility flag"

### DIFF
--- a/pkg/fedora/kernel-surface/configs/fedora.config
+++ b/pkg/fedora/kernel-surface/configs/fedora.config
@@ -7,8 +7,3 @@
 ## but enabled automatically by one of our patches.
 ##
 CONFIG_VIDEO_V4L2_SUBDEV_API=y
-
-##
-## Disable (wrong) NX compatibility flag.
-##
-# CONFIG_EFI_DXE_MEM_ATTRIBUTES is not set


### PR DESCRIPTION
This reverts commit 3d3ce1ab74c709fad0ffae4877993e16f9fa9fb4.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
